### PR TITLE
allow for a valid letter to be incorrectly used and not exclude it

### DIFF
--- a/main.go
+++ b/main.go
@@ -76,7 +76,7 @@ func main() {
 
 		prompt = promptui.Prompt{
 			Label:    "Enter pattern . = not in word, Y = wrong spot, G = correct: ",
-			Validate: validator(),
+			Validate: guessValidator(),
 		}
 		pattern, err := prompt.Run()
 		if err != nil {
@@ -88,11 +88,6 @@ func main() {
 		k.Contains = make([]string, 0)
 		k.Exact = ""
 		for i, r := range pattern {
-			if r == notInWord {
-				k.Exclude = fmt.Sprintf("%s%s", k.Exclude, string(guess[i]))
-				k.Exact = k.Exact + "."
-				continue
-			}
 			if r == wrongSpot {
 				k.Contains = append(k.Contains, string(guess[i]))
 				k.Exact = k.Exact + "."
@@ -100,8 +95,15 @@ func main() {
 			}
 			if r == rightSpot {
 				k.Exact = k.Exact + string(guess[i])
+				continue
+			}
+			if r == notInWord {
+				k.Exclude = fmt.Sprintf("%s%s", k.Exclude, string(guess[i]))
+				k.Exact = k.Exact + "."
+				continue
 			}
 		}
+		k.CleanExclude()
 
 		//fmt.Printf("KNOWLEDGE: %+v\n", *k)
 

--- a/pkg/wordle/suggest.go
+++ b/pkg/wordle/suggest.go
@@ -34,6 +34,15 @@ func NewKnowledge() *Knowledge {
 	}
 }
 
+func (k *Knowledge) CleanExclude() {
+	for _, c := range k.Exact {
+		k.Exclude = strings.ReplaceAll(k.Exclude, string(c), "")
+	}
+	for _, s := range k.Contains {
+		k.Exclude = strings.ReplaceAll(k.Exclude, s, "")
+	}
+}
+
 var (
 	dict *Dictionary
 )


### PR DESCRIPTION
Fixes #1 

Sample run - prior to this fix, TOAST w/ G.GG. would fail to find any suggestions because T was added to the exclude list.

```
❯ go run .
Wordle helper - I'm only interested in wrong guesses
Type 'EXIT' to quit
Invalid guess 1: SCALP
Enter pattern . = not in word, Y = wrong spot, G = correct: : Y.G..
Found 341 suggestions
✗ Display all 341 suggestions?: 
Invalid guess 2: BRATS
Enter pattern . = not in word, Y = wrong spot, G = correct: : ..GYY
Found 70 suggestions
AGAST AVAST DOATS ETATS FEAST FEATS FIATS GEATS GHAST GHATS GNATS GOATS HEAST HEATS HOAST IKATS JEATS KHATS KYATS MEATS MOATS NEATS QUATS SEATS SHAFT SHAKT SKATE SKATS SKATT SNATH STADE STAFF STAGE STAGS STAGY STAID STAIG STAIN STAKE STAND STANE STANG STANK STASH STATE STATS STAUN STAVE STAWS STAYS SWATH SWATS TEADS TEAKS TEAMS TEASE TEATS THANS THAWS TIANS TOADS TOAST TSADE TSADI TUANS TWAES TWATS TWAYS WHATS YEAST
Invalid guess 3: TOAST
Enter pattern . = not in word, Y = wrong spot, G = correct: : G.GG.
Found 1 suggestions
TEASE
```