### PR TITLE
Congratulate on a solve, and fix Space not cycling tile colours

### DIFF
--- a/main.go
+++ b/main.go
@@ -144,6 +144,16 @@ func run(stdin io.Reader, stdout io.Writer) error {
 			continue
 		}
 
+		// An all-green turn means the puzzle is over. It has to be handled before
+		// the candidate list, which is empty in exactly this case: the winning
+		// word is a played word, so the filter drops it like any other, and a
+		// solved puzzle would otherwise be reported as unsatisfiable feedback.
+		if answer, ok := k.Solved(); ok {
+			fmt.Fprintf(stdout, "\n%s it is. Solved in %d %s - nicely done.\n",
+				answer, round, pluralize(round, "guess", "guesses"))
+			return nil
+		}
+
 		possible, err := wordle.Suggest(dict, k)
 		if err != nil {
 			return err
@@ -172,6 +182,13 @@ func validateGuess(s string) error {
 
 func validatePattern(s string) error {
 	return wordle.ValidPattern(strings.ToUpper(strings.TrimSpace(s)))
+}
+
+func pluralize(n int, one, many string) string {
+	if n == 1 {
+		return one
+	}
+	return many
 }
 
 // orQuit turns a quit signal into a successful return and leaves real failures

--- a/main_test.go
+++ b/main_test.go
@@ -141,6 +141,28 @@ func TestContradictionReplaysTheRound(t *testing.T) {
 	requireNotContains(t, got, "Wrong guess 3")
 }
 
+func TestSolvingIsCongratulatedNotReportedAsAnError(t *testing.T) {
+	t.Parallel()
+
+	// An all-green turn leaves no candidates, because the winning word has been
+	// played and is filtered out. That used to be reported as "No word matches
+	// this feedback", telling the winner they had mistyped something.
+	first := session(t, "TOAST\nGGGGG\n")
+	requireContains(t, first, "TOAST it is. Solved in 1 guess")
+	requireNotContains(t, first, "No word matches")
+	requireNotContains(t, first, "Found 0 suggestions")
+	// The session ends on a win rather than asking for another guess.
+	requireNotContains(t, first, "Wrong guess 2")
+
+	later := session(t, strings.Join([]string{
+		"CRANE", "..G..", "n",
+		"ABAFT", "..G.G",
+		"TOAST", "GGGGG",
+	}, "\n")+"\n")
+	requireContains(t, later, "TOAST it is. Solved in 3 guesses")
+	requireNotContains(t, later, "No word matches")
+}
+
 func TestExitQuitsImmediately(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/wordle/knowledge.go
+++ b/pkg/wordle/knowledge.go
@@ -57,6 +57,14 @@ type Knowledge struct {
 	maxCount [alphabetSize]uint8
 	// guessed holds words already played, which are never suggested again.
 	guessed map[string]struct{}
+	// solved is the word whose feedback came back all green, or "".
+	//
+	// Worth recording separately because the winning word disappears from the
+	// suggestions: it is a played word, so it is filtered out like any other,
+	// and a solved puzzle looks exactly like an unsatisfiable one -- zero
+	// candidates. Without this a caller cannot tell "you won" from "you mistyped
+	// a colour somewhere".
+	solved string
 }
 
 // NewKnowledge returns Knowledge with no constraints: every word matches.
@@ -171,6 +179,9 @@ func (k *Knowledge) Apply(guess, pattern string) error {
 	k.minCount = minCount
 	k.maxCount = maxCount
 	k.guessed[guess] = struct{}{}
+	if strings.Count(pattern, string(Correct)) == WordLen {
+		k.solved = guess
+	}
 	return nil
 }
 
@@ -206,6 +217,14 @@ func (k *Knowledge) Match(word string) bool {
 
 	_, alreadyGuessed := k.guessed[word]
 	return !alreadyGuessed
+}
+
+// Solved returns the winning word and true once a turn has come back all green.
+//
+// Callers should check this before reporting on the candidate list, which is
+// empty in exactly this case.
+func (k *Knowledge) Solved() (string, bool) {
+	return k.solved, k.solved != ""
 }
 
 // Guessed reports whether word has already been played.
@@ -261,5 +280,8 @@ func (k *Knowledge) String() string {
 	b.WriteByte(']')
 
 	fmt.Fprintf(&b, " guessed=%d", len(k.guessed))
+	if k.solved != "" {
+		fmt.Fprintf(&b, " solved=%s", k.solved)
+	}
 	return b.String()
 }

--- a/pkg/wordle/knowledge_test.go
+++ b/pkg/wordle/knowledge_test.go
@@ -149,6 +149,68 @@ func TestGuessedWordsAreNotSuggested(t *testing.T) {
 	}
 }
 
+// TestSolved covers the case that made the tool tell winners they had made a
+// mistake. An all-green turn empties the candidate list, because the winning
+// word has been played and is filtered out like any other, so a solved puzzle
+// is indistinguishable from unsatisfiable feedback unless it is tracked.
+func TestSolved(t *testing.T) {
+	t.Parallel()
+
+	t.Run("an all-green turn records the answer", func(t *testing.T) {
+		t.Parallel()
+		k := NewKnowledge()
+		applyAll(t, k, [2]string{"TOAST", "GGGGG"})
+
+		answer, ok := k.Solved()
+		if !ok || answer != "TOAST" {
+			t.Errorf("Solved() = (%q, %v), want (\"TOAST\", true)", answer, ok)
+		}
+
+		// The candidate list really is empty; that is why Solved has to exist.
+		dict := DefaultDictionary()
+		possible, err := Suggest(dict, k)
+		if err != nil {
+			t.Fatalf("Suggest returned unexpected error: %v", err)
+		}
+		if len(possible) != 0 {
+			t.Errorf("Suggest = %v, want empty", possible)
+		}
+	})
+
+	t.Run("solved after several turns", func(t *testing.T) {
+		t.Parallel()
+		k := NewKnowledge()
+		applyAll(t, k,
+			[2]string{"CRANE", "..G.."},
+			[2]string{"ABAFT", "..G.G"},
+			[2]string{"TOAST", "GGGGG"},
+		)
+		if answer, ok := k.Solved(); !ok || answer != "TOAST" {
+			t.Errorf("Solved() = (%q, %v), want (\"TOAST\", true)", answer, ok)
+		}
+	})
+
+	t.Run("not solved without a full row of greens", func(t *testing.T) {
+		t.Parallel()
+		for _, pattern := range []string{".....", "GGGG.", "GG.GG", "YYYYY", "GGGGY"} {
+			k := NewKnowledge()
+			applyAll(t, k, [2]string{"TOAST", pattern})
+			if answer, ok := k.Solved(); ok {
+				t.Errorf("Solved() = (%q, true) for pattern %q, want false", answer, pattern)
+			}
+		}
+	})
+
+	t.Run("lowercase input still counts as solved", func(t *testing.T) {
+		t.Parallel()
+		k := NewKnowledge()
+		applyAll(t, k, [2]string{"toast", "ggggg"})
+		if answer, ok := k.Solved(); !ok || answer != "TOAST" {
+			t.Errorf("Solved() = (%q, %v), want (\"TOAST\", true)", answer, ok)
+		}
+	})
+}
+
 func TestApplyRejectsContradictions(t *testing.T) {
 	t.Parallel()
 

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -132,7 +132,10 @@ worker.addEventListener('message', (event: MessageEvent<SolveResponse>) => {
 
   results.render(response);
 
-  if (response.candidates.length === 1) {
+  if (response.solved !== null) {
+    const turns = lastTurns.length;
+    setStatus(`${response.solved} — solved in ${turns} ${turns === 1 ? 'guess' : 'guesses'}.`, 'info');
+  } else if (response.candidates.length === 1) {
     setStatus(`Only ${response.candidates[0]} fits. That is the answer.`, 'info');
   }
 });

--- a/web/src/solver/knowledge.ts
+++ b/web/src/solver/knowledge.ts
@@ -46,9 +46,24 @@ export class Knowledge {
   private readonly maxCount = new Uint8Array(ALPHABET).fill(WORD_LENGTH);
   private readonly played = new Set<string>();
 
+  /**
+   * The word whose feedback came back all green, or null.
+   *
+   * Worth recording separately because the winning word disappears from the
+   * suggestions: it is a played word, so it is filtered out like any other, and
+   * a solved puzzle looks exactly like an unsatisfiable one -- zero candidates.
+   * Without this the UI cannot tell "you won" from "you mistyped a colour".
+   */
+  private solvedWith: string | null = null;
+
   /** Number of turns recorded. */
   get turns(): number {
     return this.played.size;
+  }
+
+  /** The winning word once a turn has come back all green. */
+  get solved(): string | null {
+    return this.solvedWith;
   }
 
   /** Forgets everything. */
@@ -58,6 +73,7 @@ export class Knowledge {
     this.minCount.fill(0);
     this.maxCount.fill(WORD_LENGTH);
     this.played.clear();
+    this.solvedWith = null;
   }
 
   /** Returns an independent copy. */
@@ -68,6 +84,7 @@ export class Knowledge {
     copy.minCount.set(this.minCount);
     copy.maxCount.set(this.maxCount);
     for (const word of this.played) copy.played.add(word);
+    copy.solvedWith = this.solvedWith;
     return copy;
   }
 
@@ -160,6 +177,9 @@ export class Knowledge {
     this.minCount.set(minCount);
     this.maxCount.set(maxCount);
     this.played.add(guess);
+    if (pattern === CORRECT.repeat(WORD_LENGTH)) {
+      this.solvedWith = guess;
+    }
   }
 
   /**
@@ -213,6 +233,7 @@ export class Knowledge {
       banned.push(`${i + 1}:${letters}`);
     }
 
-    return `greens=${greens} counts=[${counts.join(' ')}] banned=[${banned.join(' ')}] guessed=${this.played.size}`;
+    const solved = this.solvedWith === null ? '' : ` solved=${this.solvedWith}`;
+    return `greens=${greens} counts=[${counts.join(' ')}] banned=[${banned.join(' ')}] guessed=${this.played.size}${solved}`;
   }
 }

--- a/web/src/solver/protocol.ts
+++ b/web/src/solver/protocol.ts
@@ -63,6 +63,14 @@ export interface SolveSuccess {
    * known list, which the editorially chosen puzzle does produce.
    */
   readonly likelyCandidates: number;
+  /**
+   * The winning word once a turn has come back all green, otherwise null.
+   *
+   * A solved puzzle produces zero candidates -- the winning word is a played
+   * word, so the filter drops it -- which is indistinguishable from feedback
+   * that cannot be satisfied. This is what tells the two apart.
+   */
+  readonly solved: string | null;
   /** Best guesses overall, which may well be words that cannot be the answer. */
   readonly ranked: readonly RankedGuess[];
   /**

--- a/web/src/solver/worker.ts
+++ b/web/src/solver/worker.ts
@@ -58,9 +58,29 @@ function solve(request: SolveRequest): SolveResponse {
       ok: true,
       candidates: WORDS,
       likelyCandidates: ANSWER_COUNT,
+      solved: null,
       ranked: openers.slice(0, request.limit),
       rankedCandidates: [],
       rankingSource: 'precomputed',
+      elapsedMs: performance.now() - started,
+    };
+  }
+
+  // A solved puzzle has to be recognised before anything is said about the
+  // candidate list, which is empty here: the winning word is a played word, so
+  // the filter drops it like any other. Reporting that as "no word fits this
+  // feedback" told winners they had made a mistake.
+  const solved = knowledge.solved;
+  if (solved !== null) {
+    return {
+      id: request.id,
+      ok: true,
+      candidates: [],
+      likelyCandidates: 0,
+      solved,
+      ranked: [],
+      rankedCandidates: [],
+      rankingSource: 'none',
       elapsedMs: performance.now() - started,
     };
   }
@@ -72,6 +92,7 @@ function solve(request: SolveRequest): SolveResponse {
       ok: true,
       candidates,
       likelyCandidates: 0,
+      solved: null,
       ranked: [],
       rankedCandidates: [],
       rankingSource: 'none',
@@ -125,6 +146,7 @@ function solve(request: SolveRequest): SolveResponse {
     // Every survivor, in dictionary order, so nothing is ever hidden.
     candidates: toWords(allIndices),
     likelyCandidates: likelyIndices.length,
+    solved: null,
     ranked,
     rankedCandidates,
     rankingSource,

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -247,11 +247,18 @@ body {
   outline-offset: 3px;
 }
 
-/* The cursor marker sits on the next empty slot so keyboard entry has a
- * visible caret, the way the game's own board implies one. */
+/* The caret marks the tile the keyboard acts on: the next empty slot while
+ * typing, and the last letter once the row is full, where Space cycles colour.
+ * On a coloured tile an inset underline is invisible, so it becomes a ring. */
 .tile[data-cursor='true'] {
   border-color: var(--text-muted);
   box-shadow: inset 0 -3px 0 var(--text-muted);
+}
+
+.tile[data-cursor='true'][data-filled='true'] {
+  box-shadow:
+    0 0 0 2px var(--bg),
+    0 0 0 4px var(--text-muted);
 }
 
 /* Animations mirror the game's feel: a pop as a letter lands, a flip as the
@@ -446,6 +453,14 @@ summary:focus-visible {
 
 .tally__count[data-tone='solved'] {
   color: var(--tile-correct);
+}
+
+/* The tally shows the winning word rather than a count when the puzzle is
+ * solved, so it needs the board's letter treatment, not tabular figures. */
+.tally__count[data-kind='word'] {
+  font-family: var(--font-tile);
+  font-size: clamp(1.75rem, 6vw, 2.4rem);
+  letter-spacing: 0.1em;
 }
 
 .tally__count[data-tone='empty'] {

--- a/web/src/ui/board.ts
+++ b/web/src/ui/board.ts
@@ -247,10 +247,19 @@ export class Board {
         event.preventDefault();
         this.commit(row);
         break;
-      case ' ':
+      case ' ': {
         event.preventDefault();
-        if (this.cursor < row.letters.length) this.cycleMark(row, this.cursor);
+        // The caret sits *past* the last letter, so on a full row `cursor`
+        // equals the length and a naive bounds check rejected every press --
+        // Space worked only mid-word, which is exactly when there is nothing to
+        // colour. Clamp onto the last tile instead.
+        const column = Math.min(this.cursor, row.letters.length - 1);
+        if (column >= 0) {
+          this.cursor = column;
+          this.cycleMark(row, column);
+        }
         break;
+      }
       case 'ArrowLeft':
         event.preventDefault();
         this.cursor = Math.max(0, this.cursor - 1);
@@ -350,7 +359,12 @@ export class Board {
           delete tile.dataset['mark'];
         }
 
-        if (isActive && column === this.cursor && !letter) {
+        // The caret marks the tile the keyboard acts on. On a full row that is
+        // the last tile rather than the (nonexistent) next empty one, and it has
+        // to stay visible once the tile has a letter, or Space appears to do
+        // nothing to nothing in particular.
+        const caret = Math.min(this.cursor, WORD_LENGTH - 1);
+        if (isActive && column === caret) {
           tile.dataset['cursor'] = 'true';
         } else {
           delete tile.dataset['cursor'];

--- a/web/src/ui/results.ts
+++ b/web/src/ui/results.ts
@@ -49,11 +49,22 @@ export class Results {
   render(result: SolveSuccess): void {
     const { candidates, likelyCandidates, ranked, rankedCandidates, rankingSource } = result;
 
+    // Solved is not "zero candidates". The winning word is filtered out for
+    // having been played, so a win and unsatisfiable feedback both leave the
+    // list empty, and the page used to congratulate winners with "no word fits
+    // this feedback, one of the rows is likely off".
+    if (result.solved !== null) {
+      this.renderSolved(result.solved);
+      return;
+    }
+
     // The headline is the count that has ever been a solution, because that is
     // the number a player actually cares about. The full total is still shown
     // beside it, so nothing looks like it was silently discarded.
     const headline = likelyCandidates > 0 ? likelyCandidates : candidates.length;
     this.elements.count.textContent = numberFormat.format(headline);
+    // Cleared so a previous solve does not leave the tally styled as a word.
+    delete this.elements.count.dataset['kind'];
     this.elements.count.dataset['tone'] =
       candidates.length === 0 ? 'empty' : headline === 1 ? 'solved' : 'normal';
 
@@ -78,6 +89,19 @@ export class Results {
 
     this.renderRanked(ranked, rankedCandidates, rankingSource, candidates.length);
     this.renderAllWords(candidates);
+  }
+
+  private renderSolved(answer: string): void {
+    this.elements.count.textContent = answer;
+    this.elements.count.dataset['tone'] = 'solved';
+    this.elements.count.dataset['kind'] = 'word';
+    this.elements.label.textContent = 'Solved. Nicely done.';
+
+    this.elements.ranked.replaceChildren(
+      note('That is the answer — nothing left to narrow down. Start over for the next puzzle.'),
+    );
+    this.elements.allWords.hidden = true;
+    this.elements.allWords.open = false;
   }
 
   private renderRanked(

--- a/web/test/solved.test.ts
+++ b/web/test/solved.test.ts
@@ -1,0 +1,94 @@
+// Copyright 2022 Mike Helmick
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, expect, it } from 'vitest';
+
+import { suggest } from '../src/solver/filter';
+import { Knowledge } from '../src/solver/knowledge';
+
+// An all-green turn empties the candidate list: the winning word has been
+// played, so the filter drops it like any other. That makes a solved puzzle
+// indistinguishable from feedback that cannot be satisfied, and the page used
+// to greet winners with "No word fits this feedback. Check the colours you
+// entered — one of the rows is likely off."
+
+function knowing(...turns: Array<[string, string]>): Knowledge {
+  const k = new Knowledge();
+  for (const [guess, pattern] of turns) k.apply(guess, pattern);
+  return k;
+}
+
+describe('a solved puzzle', () => {
+  it('is not reported as unsatisfiable feedback', () => {
+    const k = knowing(['TOAST', 'GGGGG']);
+
+    // The empty list is real, and is exactly why `solved` has to be tracked
+    // separately rather than inferred from the count.
+    expect(suggest(k)).toEqual([]);
+    expect(k.solved).toBe('TOAST');
+  });
+
+  it('records the answer after several turns', () => {
+    const k = knowing(['CRANE', '..G..'], ['ABAFT', '..G.G'], ['TOAST', 'GGGGG']);
+    expect(k.solved).toBe('TOAST');
+  });
+
+  it('stays unsolved without a full row of greens', () => {
+    for (const pattern of ['.....', 'GGGG.', 'GG.GG', 'YYYYY', 'GGGGY']) {
+      expect(knowing(['TOAST', pattern]).solved, `pattern ${pattern}`).toBeNull();
+    }
+  });
+
+  it('normalizes lowercase input', () => {
+    expect(knowing(['toast', 'ggggg']).solved).toBe('TOAST');
+  });
+
+  it('is cleared by reset and carried by clone', () => {
+    const k = knowing(['TOAST', 'GGGGG']);
+
+    const copy = k.clone();
+    expect(copy.solved).toBe('TOAST');
+
+    k.reset();
+    expect(k.solved).toBeNull();
+    // The clone is independent, so it keeps its own record.
+    expect(copy.solved).toBe('TOAST');
+  });
+
+  it('shows up in the debug description', () => {
+    expect(knowing(['TOAST', 'GGGGG']).describe()).toContain('solved=TOAST');
+    expect(knowing(['TOAST', '.....']).describe()).not.toContain('solved=');
+  });
+
+  it('distinguishes a win from genuinely impossible feedback', () => {
+    // Both leave zero candidates. Only one of them is good news.
+    //
+    // Four all-grey guesses are needed to exhaust the dictionary: three still
+    // leave HUDUD standing, which is a fair reminder that "no letters at all"
+    // is a weaker constraint than it looks.
+    const won = knowing(['TOAST', 'GGGGG']);
+    const impossible = knowing(
+      ['CRANE', '.....'],
+      ['TOAST', '.....'],
+      ['MILKY', '.....'],
+      ['HUDUD', '.....'],
+    );
+
+    expect(suggest(won)).toEqual([]);
+    expect(won.solved).toBe('TOAST');
+
+    expect(suggest(impossible)).toEqual([]);
+    expect(impossible.solved).toBeNull();
+  });
+});


### PR DESCRIPTION
Two bugs found in real use.

## Solving the puzzle was reported as an error

Entering five greens showed:

> **0** words possible
> No word fits this feedback. Check the colours you entered — one of the rows is likely off.

An all-green turn leaves zero candidates, because the winning word has been played and the filter drops it like any other. That is indistinguishable from feedback that cannot be satisfied — so winning looked exactly like a mistake.

`Knowledge` now records the word whose feedback came back all green, which is what separates the two cases. The page shows the answer and "Solved. Nicely done." where the tally normally goes, and hides the ranking and word list since there is nothing left to narrow.

**The CLI had the same bug**, and the same fix: it now prints `TOAST it is. Solved in 3 guesses - nicely done.` and stops, instead of asking for a fourth wrong guess.

## Space did not cycle tile colours

The caret sits *past* the last letter, so on a full row `cursor` equals the row length and the bounds check `cursor < letters.length` rejected every press. Space worked only mid-word — exactly when there is nothing worth colouring. It now clamps onto the last tile.

Related: the caret only rendered on an *empty* tile, so once a row was full there was no indication of which tile the keyboard would act on. It now marks the active tile whether or not it holds a letter, drawn as a ring rather than an underline, since an inset line is invisible against a coloured tile.

## Verification

Driven in a browser against the production build, not just unit-tested: Space cycles on a full row and follows the arrow keys, a solved board shows the congratulation, and undo and reset both recover from the solved state.

Regression tests on both sides. One of them needed four all-grey guesses to genuinely exhaust the dictionary — three still leave `HUDUD` standing, which is a fair reminder that "no letters at all" constrains less than it looks.

79 web tests, `go test -race`, vet, staticcheck, govulncheck all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)