### PR TITLE
Add on-screen keyboard with colour "shift" keys to the web app

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -44,6 +44,8 @@
             <span class="legend__item"><i class="swatch swatch--correct"></i>correct</span>
           </div>
 
+          <div class="keyboard" id="keyboard" role="group" aria-label="On-screen keyboard"></div>
+
           <div class="controls">
             <button type="button" class="button button--primary" id="submit" disabled>
               Record turn
@@ -59,6 +61,11 @@
               <li>Click each tile (or press <kbd>Space</kbd>) to cycle its colour to match the game.</li>
               <li>Press <kbd>Enter</kbd>, or use <b>Record turn</b>, to record it.</li>
             </ol>
+            <p>
+              On the on-screen keyboard, tap <b>Wrong spot</b> or <b>Correct</b> first and the whole
+              keyboard changes colour: the next letter you tap is entered in that colour, then it
+              reverts. Tap the same colour again to cancel it.
+            </p>
             <p>
               Everything runs in your browser. Nothing you type leaves this page, and the page makes no
               network requests at all.

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -16,6 +16,7 @@ import './styles.css';
 
 import type { SolveRequest, SolveResponse, Turn } from './solver/protocol';
 import { Board } from './ui/board';
+import { Keyboard } from './ui/keyboard';
 import { Results } from './ui/results';
 
 const RANKED_LIMIT = 10;
@@ -29,6 +30,7 @@ function required<T extends Element>(id: string): T {
 
 const elements = {
   board: required<HTMLElement>('board'),
+  keyboard: required<HTMLElement>('keyboard'),
   status: required<HTMLElement>('status'),
   submit: required<HTMLButtonElement>('submit'),
   undo: required<HTMLButtonElement>('undo'),
@@ -106,6 +108,11 @@ function setStatus(text: string, tone: 'info' | 'error'): void {
   elements.status.dataset['tone'] = tone;
 }
 
+// Declared before the board so the board's construction-time onStateChanged can
+// reference it; it is still undefined then, so setPending is skipped until the
+// keyboard exists.
+let keyboard: Keyboard | undefined;
+
 const board = new Board(elements.board, {
   onTurnsChanged: solve,
   onMessage: setStatus,
@@ -113,7 +120,15 @@ const board = new Board(elements.board, {
     elements.submit.disabled = !state.canSubmit;
     elements.undo.disabled = !state.canUndo;
     elements.reset.disabled = !state.canReset;
+    keyboard?.setPending(state.pendingMark);
   },
+});
+
+keyboard = new Keyboard(elements.keyboard, {
+  onKey: (letter) => board.type(letter),
+  onEnter: () => board.submit(),
+  onBackspace: () => board.backspace(),
+  onArm: (mark) => board.setPendingShift(mark),
 });
 
 elements.submit.addEventListener('click', () => board.submit());

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -379,6 +379,114 @@ body {
   background: var(--tile-correct);
 }
 
+/* ---------------------------------------------------------------- keyboard */
+
+/* The on-screen keyboard is what makes the app usable on a phone. It is capped
+ * so it never stretches wider than the board's column on desktop, and
+ * `touch-action: manipulation` disables the double-tap-to-zoom delay so taps
+ * register instantly. */
+.keyboard {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  width: 100%;
+  max-width: 30rem;
+  touch-action: manipulation;
+  user-select: none;
+}
+
+.keyboard__row {
+  display: flex;
+  justify-content: center;
+  gap: 6px;
+}
+
+.key {
+  flex: 1;
+  min-width: 0;
+  height: clamp(2.75rem, 10vw, 3.4rem);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  padding: 0 0.35rem;
+  font-family: inherit;
+  font-size: 0.875rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  color: var(--text);
+  background: var(--surface-raised);
+  border: 1px solid var(--rule);
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: background-color 100ms ease, border-color 100ms ease, color 100ms ease;
+}
+
+.key:hover {
+  border-color: var(--tile-filled-border);
+}
+
+.key:focus-visible {
+  outline: 3px solid var(--accent);
+  outline-offset: 2px;
+}
+
+/* Enter and Backspace take a little more room so they stay easy to hit. */
+.key--wide {
+  flex: 1.5;
+  font-size: 0.75rem;
+}
+
+/* Arming a shift tints every letter key that colour, so the keyboard itself
+ * shows what the next letter will be. Enter and Backspace stay neutral so they
+ * remain findable in a sea of colour. */
+.keyboard[data-arm='present'] .key--letter {
+  color: var(--tile-text);
+  background: var(--tile-present);
+  border-color: transparent;
+}
+
+.keyboard[data-arm='correct'] .key--letter {
+  color: var(--tile-text);
+  background: var(--tile-correct);
+  border-color: transparent;
+}
+
+.key__swatch {
+  width: 0.9rem;
+  height: 0.9rem;
+  flex: none;
+  border-radius: 2px;
+}
+
+.key--shift-present .key__swatch {
+  background: var(--tile-present);
+}
+
+.key--shift-correct .key__swatch {
+  background: var(--tile-correct);
+}
+
+/* A pressed shift fills with its colour, matching the tint it puts on the
+ * letters. */
+.key--shift[aria-pressed='true'] {
+  color: var(--tile-text);
+  border-color: transparent;
+}
+
+.key--shift-present[aria-pressed='true'] {
+  background: var(--tile-present);
+}
+
+.key--shift-correct[aria-pressed='true'] {
+  background: var(--tile-correct);
+}
+
+/* Against the filled shift key the swatch would vanish, so give it an outline. */
+.key--shift[aria-pressed='true'] .key__swatch {
+  box-shadow: inset 0 0 0 1px var(--tile-text);
+}
+
 /* ---------------------------------------------------------------- controls */
 
 .controls {

--- a/web/src/ui/board.ts
+++ b/web/src/ui/board.ts
@@ -19,7 +19,15 @@ const MAX_ROWS = 6;
 
 /** Tile states, in the order clicking cycles through them. */
 const MARKS = ['absent', 'present', 'correct'] as const;
-type Mark = (typeof MARKS)[number];
+export type Mark = (typeof MARKS)[number];
+
+/**
+ * The colour armed by a "shift" key on the on-screen keyboard, applied to the
+ * next letter typed. `null` is the resting default, which enters letters as
+ * `absent` (grey). Only the two coloured states can be armed -- grey is what you
+ * get by not arming anything.
+ */
+export type PendingMark = 'present' | 'correct' | null;
 
 const MARK_TO_CHAR: Record<Mark, string> = {
   absent: ABSENT,
@@ -46,6 +54,11 @@ export interface BoardState {
   readonly canSubmit: boolean;
   readonly canUndo: boolean;
   readonly canReset: boolean;
+  /**
+   * The colour currently armed for the next letter, or `null` for the default.
+   * The on-screen keyboard reads this to tint itself and light the shift keys.
+   */
+  readonly pendingMark: PendingMark;
 }
 
 export interface BoardOptions {
@@ -73,6 +86,8 @@ export class Board {
   private readonly rows: Row[] = [];
   private cursor = 0;
   private active = 0;
+  /** Colour armed for the next typed letter; see {@link PendingMark}. */
+  private pendingMark: PendingMark = null;
 
   constructor(
     private readonly root: HTMLElement,
@@ -116,6 +131,33 @@ export class Board {
     if (row && !row.committed) this.commit(row);
   }
 
+  /**
+   * Types a letter into the active row, as pressing a letter key does. Used by
+   * the on-screen keyboard; the letter takes whatever colour is currently armed.
+   */
+  type(letter: string): void {
+    const row = this.rows[this.active];
+    if (!row || row.committed) return;
+    this.typeLetter(row, letter.toUpperCase());
+  }
+
+  /** Deletes a letter from the active row, as pressing Backspace does. */
+  backspace(): void {
+    const row = this.rows[this.active];
+    if (!row || row.committed) return;
+    this.deleteLetter(row);
+  }
+
+  /**
+   * Arms (or disarms) a colour for the next letter, driven by the keyboard's
+   * shift keys. Tapping the already-armed colour cancels it, back to the grey
+   * default -- the same toggle a Shift key gives you.
+   */
+  setPendingShift(mark: 'present' | 'correct'): void {
+    this.pendingMark = this.pendingMark === mark ? null : mark;
+    this.render();
+  }
+
   reset(): void {
     for (const row of this.rows) {
       row.letters = [];
@@ -124,6 +166,7 @@ export class Board {
     }
     this.active = 0;
     this.cursor = 0;
+    this.pendingMark = null;
     this.render();
     this.options.onTurnsChanged(this.turns());
     this.options.onMessage('', 'info');
@@ -144,6 +187,7 @@ export class Board {
     this.rows[last]!.committed = false;
     this.active = last;
     this.cursor = WORD_LENGTH;
+    this.pendingMark = null;
     this.render();
     this.options.onTurnsChanged(this.turns());
     this.options.onMessage('Turn reopened. Adjust it and press Enter.', 'info');
@@ -162,6 +206,7 @@ export class Board {
     }
     this.active = turnIndex;
     this.cursor = WORD_LENGTH;
+    this.pendingMark = null;
     this.render();
     this.shake(row);
     this.options.onMessage(message, 'error');
@@ -277,17 +322,24 @@ export class Board {
 
   private typeLetter(row: Row, letter: string): void {
     if (this.cursor < row.letters.length) {
-      // Overwrite in place, keeping whatever colour was already chosen.
+      // Overwrite in place. An armed shift recolours the tile; otherwise keep
+      // whatever colour was already chosen.
       row.letters[this.cursor] = letter;
+      if (this.pendingMark) row.marks[this.cursor] = this.pendingMark;
       this.cursor = Math.min(WORD_LENGTH - 1, this.cursor + 1);
+      // The shift is one-shot: consumed by the letter it coloured.
+      this.pendingMark = null;
       this.render();
       return;
     }
     if (row.letters.length >= WORD_LENGTH) return;
 
     row.letters.push(letter);
-    row.marks.push('absent');
+    // A new letter takes the armed colour, or grey when nothing is armed.
+    row.marks.push(this.pendingMark ?? 'absent');
     this.cursor = row.letters.length;
+    // The shift is one-shot: consumed by the letter it coloured.
+    this.pendingMark = null;
     this.render();
 
     const tile = row.tiles[row.letters.length - 1]!;
@@ -316,6 +368,7 @@ export class Board {
     row.committed = true;
     this.active = Math.min(this.active + 1, MAX_ROWS - 1);
     this.cursor = 0;
+    this.pendingMark = null;
     this.render();
 
     row.tiles.forEach((tile, i) => {
@@ -387,6 +440,7 @@ export class Board {
       canSubmit: this.canSubmit,
       canUndo: this.committedCount > 0,
       canReset: !this.isEmpty,
+      pendingMark: this.pendingMark,
     });
   }
 }

--- a/web/src/ui/keyboard.ts
+++ b/web/src/ui/keyboard.ts
@@ -1,0 +1,144 @@
+// Copyright 2022 Mike Helmick
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { PendingMark } from './board';
+
+/** The three letter rows, in the familiar QWERTY arrangement. */
+const LETTER_ROWS = ['QWERTYUIOP', 'ASDFGHJKL', 'ZXCVBNM'] as const;
+
+/** The colours the shift keys arm, with the label each key carries. */
+const SHIFT_KEYS: ReadonlyArray<{ mark: 'present' | 'correct'; label: string }> = [
+  { mark: 'present', label: 'Wrong spot' },
+  { mark: 'correct', label: 'Correct' },
+];
+
+export interface KeyboardOptions {
+  /** A letter key was pressed. */
+  onKey(letter: string): void;
+  /** The Enter key was pressed. */
+  onEnter(): void;
+  /** The Backspace key was pressed. */
+  onBackspace(): void;
+  /** A colour shift key was pressed; the board decides whether to arm or cancel. */
+  onArm(mark: 'present' | 'correct'): void;
+}
+
+/**
+ * The on-screen keyboard. It exists so the app is usable on a phone, where there
+ * is no physical keyboard to type a guess.
+ *
+ * Its twist is that the yellow and green markers are *shift* keys: pressing one
+ * tints the whole keyboard and arms that colour, so the next letter is entered
+ * already coloured. The board owns the armed colour; this component only reports
+ * presses upward and reflects the armed colour back down via {@link setPending}.
+ */
+export class Keyboard {
+  private readonly shiftButtons = new Map<'present' | 'correct', HTMLButtonElement>();
+
+  constructor(
+    private readonly root: HTMLElement,
+    private readonly options: KeyboardOptions,
+  ) {
+    this.root.classList.add('keyboard');
+
+    this.root.append(this.buildLetterRow(LETTER_ROWS[0]));
+    this.root.append(this.buildLetterRow(LETTER_ROWS[1]));
+    this.root.append(this.buildBottomRow(LETTER_ROWS[2]));
+    this.root.append(this.buildShiftRow());
+  }
+
+  /**
+   * Reflects the board's armed colour: tints the letter keys via a data
+   * attribute the stylesheet keys off, and lights the matching shift key.
+   */
+  setPending(mark: PendingMark): void {
+    if (mark) {
+      this.root.dataset['arm'] = mark;
+    } else {
+      delete this.root.dataset['arm'];
+    }
+    for (const [keyMark, button] of this.shiftButtons) {
+      button.setAttribute('aria-pressed', String(keyMark === mark));
+    }
+  }
+
+  private buildLetterRow(letters: string): HTMLDivElement {
+    const row = this.buildRow();
+    for (const letter of letters) {
+      row.append(
+        this.buildKey(letter, 'key key--letter', () => this.options.onKey(letter)),
+      );
+    }
+    return row;
+  }
+
+  /** The Z-row, flanked by Enter and Backspace as in the game's own keyboard. */
+  private buildBottomRow(letters: string): HTMLDivElement {
+    const row = this.buildRow();
+    row.append(this.buildKey('Enter', 'key key--wide', () => this.options.onEnter()));
+    for (const letter of letters) {
+      row.append(
+        this.buildKey(letter, 'key key--letter', () => this.options.onKey(letter)),
+      );
+    }
+    // A wide backspace glyph; the accessible name says what it does.
+    const back = this.buildKey('⌫', 'key key--wide', () => this.options.onBackspace());
+    back.setAttribute('aria-label', 'Backspace');
+    row.append(back);
+    return row;
+  }
+
+  private buildShiftRow(): HTMLDivElement {
+    const row = this.buildRow();
+    for (const { mark, label } of SHIFT_KEYS) {
+      row.append(this.buildShiftKey(mark, label));
+    }
+    return row;
+  }
+
+  private buildShiftKey(mark: 'present' | 'correct', label: string): HTMLButtonElement {
+    const button = this.buildKey(label, `key key--shift key--shift-${mark}`, () =>
+      this.options.onArm(mark),
+    );
+    button.setAttribute('aria-pressed', 'false');
+
+    // A swatch makes the colour legible next to the label, matching the legend.
+    const swatch = document.createElement('i');
+    swatch.className = 'key__swatch';
+    swatch.setAttribute('aria-hidden', 'true');
+    button.prepend(swatch);
+
+    this.shiftButtons.set(mark, button);
+    return button;
+  }
+
+  private buildRow(): HTMLDivElement {
+    const row = document.createElement('div');
+    row.className = 'keyboard__row';
+    return row;
+  }
+
+  private buildKey(label: string, className: string, onClick: () => void): HTMLButtonElement {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = className;
+    button.append(document.createTextNode(label));
+    button.addEventListener('click', onClick);
+    // Keep focus on the body so a following physical Space still cycles the
+    // active tile's colour rather than re-activating this button. Tab users who
+    // deliberately focus a key still get normal Enter/Space activation.
+    button.addEventListener('mousedown', (event) => event.preventDefault());
+    return button;
+  }
+}


### PR DESCRIPTION
The browser front end only accepted letters from a physical keyboard, so it
was unusable on a phone. Add an on-screen keyboard, and make the yellow and
green markers shift keys: tapping one tints the whole keyboard and arms that
colour, so the next letter is entered already coloured, then it reverts to the
grey default (one-shot, like Shift). Tapping the armed colour again cancels it.

The board stays the single source of truth for the armed colour, so physical
typing honours it too. The new Keyboard component only reports presses upward
and reflects the armed colour back down. No solver or word-data changes.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01T5h7PHeciQcXnFQX6GHfgv