### PR TITLE
Auto-colour a letter green when its position is already known

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -67,6 +67,10 @@
               reverts. Tap the same colour again to cancel it.
             </p>
             <p>
+              Once a letter is known to be in the right spot, typing it there again colours the tile
+              green for you automatically.
+            </p>
+            <p>
               Everything runs in your browser. Nothing you type leaves this page, and the page makes no
               network requests at all.
             </p>

--- a/web/src/ui/board.ts
+++ b/web/src/ui/board.ts
@@ -320,12 +320,34 @@ export class Board {
     }
   };
 
+  /**
+   * The letter known to sit at each position, deduced from the greens of
+   * committed turns. A green is a certainty -- the solver treats a green
+   * position as fixed for the rest of the game -- so a letter typed into a
+   * position already known green must itself be green. Greens never disagree
+   * across turns, so a last-writer merge is enough.
+   */
+  private knownCorrect(): (string | undefined)[] {
+    const known: (string | undefined)[] = [];
+    for (const row of this.rows) {
+      if (!row.committed) continue;
+      row.marks.forEach((mark, column) => {
+        if (mark === 'correct') known[column] = row.letters[column];
+      });
+    }
+    return known;
+  }
+
   private typeLetter(row: Row, letter: string): void {
     if (this.cursor < row.letters.length) {
-      // Overwrite in place. An armed shift recolours the tile; otherwise keep
-      // whatever colour was already chosen.
+      // Overwrite in place. An armed shift recolours the tile; otherwise adopt a
+      // known green for this letter, and failing that keep the existing colour.
       row.letters[this.cursor] = letter;
-      if (this.pendingMark) row.marks[this.cursor] = this.pendingMark;
+      if (this.pendingMark) {
+        row.marks[this.cursor] = this.pendingMark;
+      } else if (this.knownCorrect()[this.cursor] === letter) {
+        row.marks[this.cursor] = 'correct';
+      }
       this.cursor = Math.min(WORD_LENGTH - 1, this.cursor + 1);
       // The shift is one-shot: consumed by the letter it coloured.
       this.pendingMark = null;
@@ -334,9 +356,12 @@ export class Board {
     }
     if (row.letters.length >= WORD_LENGTH) return;
 
+    const position = row.letters.length;
+    // A new letter takes the armed colour; otherwise green if this position is
+    // already known to be this letter, else grey.
+    const autoMark: Mark = this.knownCorrect()[position] === letter ? 'correct' : 'absent';
     row.letters.push(letter);
-    // A new letter takes the armed colour, or grey when nothing is armed.
-    row.marks.push(this.pendingMark ?? 'absent');
+    row.marks.push(this.pendingMark ?? autoMark);
     this.cursor = row.letters.length;
     // The shift is one-shot: consumed by the letter it coloured.
     this.pendingMark = null;


### PR DESCRIPTION
## Summary

When a committed guess has marked a letter green at a position, that position is fixed for the rest of the game. Typing that same letter there again now colours the tile green automatically, so the player no longer has to arm the green shift or cycle the tile every guess.

This is a follow-up to the on-screen keyboard (merged in #7); it builds on that work.

## Why green only

A green is a certainty — the solver's `Knowledge` model treats a green position as fixed, and a later guess that disagrees is a contradiction. So a letter typed into a position already known green *must* be green. Yellow can't be inferred: whether a letter is still misplaced next guess depends on the hidden word, so yellow is deliberately left to the player.

## Behaviour / precedence

- Derived synchronously from the board's own committed rows (a new `knownCorrect()` helper), so it keeps up with typing — no solver round-trip.
- An explicitly armed colour shift still wins over the inferred green.
- Tiles remain fully editable — clicking a tile (or pressing Space) still cycles its colour, so any auto-green can be overridden.
- No change to `commit`, the solver, the keyboard component, or the serialized `{ guess, pattern }` shape.

## Changes

- `web/src/ui/board.ts` — `knownCorrect()` helper + auto-green default in `typeLetter`.
- `web/index.html` — one explanatory sentence in the help block.

## Verification

- `npm run typecheck`, `npm test` (79 pass), `npm run build` — all green.
- Drove the built app in Chromium: guess 1 `CRANE` with E marked green and committed → guess 2 typing E at position 5 auto-greens with nothing armed; typing X there stays gray; arming yellow then typing E yields present (override wins).

---
_Generated by [Claude Code](https://claude.ai/code/session_01T5h7PHeciQcXnFQX6GHfgv)_